### PR TITLE
Various improvements to reduce traffic

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ module.exports = function airswarm (name, opts, fn) {
 
     server.on('close', function () {
       clearInterval(interval)
+      mdns.destroy()
     })
 
     function respond () {

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function airswarm (name, opts, fn) {
   if (!opts) opts = {}
 
   var limit = opts.limit || Infinity
-  var delay = opts.delay || 3000
+  var delay = opts.delay || [50000, 70000]
   var mdns = multicastdns()
   var connections = {}
   var timeout = null

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports = function airswarm (name, opts, fn) {
   if (!opts) opts = {}
 
   var limit = opts.limit || Infinity
+  var delay = opts.delay || 3000
   var mdns = multicastdns()
   var connections = {}
 
@@ -48,7 +49,7 @@ module.exports = function airswarm (name, opts, fn) {
     })
 
     update()
-    var interval = setInterval(update, 3000)
+    var interval = setInterval(update, delay)
 
     server.on('close', function () {
       clearInterval(interval)

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ module.exports = function airswarm (name, opts, fn) {
       var remoteId = host + ':' + port
       if (remoteId === id) return
       if (connections[remoteId]) return
-      if (remoteId < id) return respond()
+      if (remoteId < id) return
 
       var sock = connections[remoteId] = net.connect(port, host)
 


### PR DESCRIPTION
These are some changes to reduce MDNS traffic between peers (and thus also reduce CPU load).

I don't believe the changes up to and including 7b6108e can have adverse effects, but while 8452cb8 and 4807db4 improve things for my specific use-case, it felt like there may have been reasons for the old ways.

Some background: I'm using this library as a discovery mechanism for a microservices project. Most services actually run on the same machine (a Raspberry Pi 3), sometimes parts run on my regular workstation while I develop them. So all communication is on a fairly reliable local network.
